### PR TITLE
Fix compile and shutdown before exiting test

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -7,6 +7,8 @@
     <maintainer email="bassamarco91@gmail.com">Marco Bassa</maintainer>
     <license>BSD</license>
     <buildtool_depend>ament_cmake</buildtool_depend>
+    <depend>rclcpp</depend>
+    <depend>rcpputils</depend>
     <depend>std_srvs</depend>
     <depend>std_msgs</depend>
     <test_depend>ament_cmake_gtest</test_depend>

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(ament_cmake_ros REQUIRED)
 find_package(rclcpp REQUIRED)
+find_package(rcpputils REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
 
@@ -9,7 +10,7 @@ include("cmake/cm_add_isolated_gtest_with_command.cmake")
 
 ament_add_gtest_executable(test_pub_string test_pub_string.cpp)
 target_link_libraries(test_pub_string gtest_main)
-ament_target_dependencies(test_pub_string std_msgs std_srvs rclcpp)
+ament_target_dependencies(test_pub_string std_msgs std_srvs rclcpp rcpputils)
 
 cm_add_isolated_gtest_with_command(
   test_pub_string
@@ -24,4 +25,3 @@ cm_add_isolated_gtest_with_command(
     TEST_DIR=${TEST_DIR}
     TEST_LAUNCH_DIR=${TEST_LAUNCH_DIR}
     TEST_EXECUTABLE=$<TARGET_FILE:test_pub_string>)
-

--- a/test/test_pub_string.cpp
+++ b/test/test_pub_string.cpp
@@ -2,6 +2,8 @@
 
 #include "test_fixture.hpp"
 
+#include "rcpputils/scope_exit.hpp"
+
 using namespace testing;
 using namespace std::chrono_literals;
 
@@ -16,6 +18,8 @@ TEST_F(TestFixture, testPubString) {
 
 int main(int argc, char** argv) {
   rclcpp::init(argc, argv);
+  auto always_shutdown = rcpputils::make_scope_exit(
+    [](){rclcpp::shutdown();});
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
- Add necessary dependencies to compile in a minimal workspace
- Fix issue where test crashes when returning due to https://github.com/ros2/rmw_zenoh?tab=readme-ov-file#known-issues

@nirwester it would be great if we can get this test be part of the nightly ROS 2 CI. Do you mind adding it to [system_tests/test_communication](https://github.com/ros2/system_tests/tree/rolling/test_communication)?